### PR TITLE
fix: gh-page action deletes CNAME

### DIFF
--- a/.github/workflows/deploy_ghpage.yml
+++ b/.github/workflows/deploy_ghpage.yml
@@ -24,3 +24,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          cname: oss.hust.openatom.club
+


### PR DESCRIPTION
修复了会导致自定义域名失效的部署bug