### PR TITLE
ci: add workflows of website build and markdown lint

### DIFF
--- a/.github/workflows/.zhlintrc
+++ b/.github/workflows/.zhlintrc
@@ -1,0 +1,6 @@
+{
+  "preset": "default",
+  "rules": {
+    "halfwidthPunctuation": "（），。、"
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,9 @@
 name: build
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
-      - main
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: pip3 install -r requirements.txt
+      
+    - name: Build docs
+      run: |
+        mkdocs -v build

--- a/.github/workflows/lint-all.yml
+++ b/.github/workflows/lint-all.yml
@@ -1,0 +1,50 @@
+name: Lint All
+
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install zhlint
+        run: yarn global add zhlint
+
+      - name: Lint all Markdown files
+        run: |
+          mkdir -p linted_output
+          file_list="linted_output/file_list.txt"
+          linted_failed_file=$(mktemp)
+          echo 0 > "$linted_failed_file"
+          find . -type f -name '*.md' | while read -r file; do
+            set +e
+            zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file"
+            if [ $? -ne 0 ]; then
+              echo 1 > "$linted_failed_file"
+              echo "$file" >> "$file_list"
+              output_file="linted_output/report_and_suggested_fixes/$file"
+              mkdir -p "$(dirname "$output_file")"
+              zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file" --output="$output_file" > "$output_file.log" 2>&1
+            fi
+            set -e
+          done
+          linted_failed=$(cat "$linted_failed_file")
+          rm "$linted_failed_file"
+          echo "linted_failed=$linted_failed" >> "$GITHUB_ENV"
+
+      - name: Upload linted Markdown
+        uses: actions/upload-artifact@v4
+        with:
+          name: linted-markdown
+          path: linted_output/
+
+      - name: Check lint errors
+        run: |
+          set -e
+          if [ "${{ env.linted_failed }}" -ne 0 ]; then
+            echo "Linting errors found. Please check the reports and suggested fixes in uploaded artifact."
+            exit 1
+          fi

--- a/.github/workflows/lint-all.yml
+++ b/.github/workflows/lint-all.yml
@@ -27,7 +27,7 @@ jobs:
               echo "$file" >> "$file_list"
               output_file="linted_output/report_and_suggested_fixes/$file"
               mkdir -p "$(dirname "$output_file")"
-              zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file" --output="$output_file" > "$output_file.log" 2>&1
+              zhlint --config "$GITHUB_WORKSPACE"/.github/workflows/.zhlintrc "$file" --output="$output_file" > "$output_file.log" 2>&1
             fi
             set -e
           done

--- a/.github/workflows/lint-all.yml
+++ b/.github/workflows/lint-all.yml
@@ -21,7 +21,7 @@ jobs:
           echo 0 > "$linted_failed_file"
           find . -type f -name '*.md' | while read -r file; do
             set +e
-            zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file"
+            zhlint --config "$GITHUB_WORKSPACE"/.github/workflows/.zhlintrc "$file"
             if [ $? -ne 0 ]; then
               echo 1 > "$linted_failed_file"
               echo "$file" >> "$file_list"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,63 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/*.md' # Only run on Markdown file changes
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install zhlint
+        run: yarn global add zhlint
+
+      - name: Get changed Markdown files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: '**/*.md'
+
+      - name: Lint Markdown files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          mkdir -p linted_output
+          file_list="linted_output/file_list.txt"
+          linted_failed=0
+          for file in ${{ env.ALL_CHANGED_FILES }}; do
+            set +e
+            zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file"
+            if [ $? -ne 0 ]; then
+              linted_failed=1
+              echo "$file" >> "$file_list"
+              output_file="linted_output/report_and_suggested_fixes/$file"
+              mkdir -p "$(dirname "$output_file")"
+              zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file" --output="$output_file" > "$output_file.log" 2>&1
+            fi
+            set -e
+          done
+          echo "linted_failed=$linted_failed" >> "$GITHUB_ENV"
+
+      - name: Upload Linted Markdown
+        uses: actions/upload-artifact@v4
+        with:
+          name: linted-markdown
+          path: linted_output/
+
+      - name: Check lint errors
+        run: |
+          set -e
+          if [ "${{ env.linted_failed }}" -ne 0 ]; then
+            echo "Linting errors found. Please check the reports and suggested fixes in the job [Lint Markdown files]. Otherwise, you can download report files in uploaded artifact."
+            exit 1
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - main
+      - '*'
     paths:
       - '**/*.md' # Only run on Markdown file changes
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
               echo "$file" >> "$file_list"
               output_file="linted_output/report_and_suggested_fixes/$file"
               mkdir -p "$(dirname "$output_file")"
-              zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file" --output="$output_file" > "$output_file.log" 2>&1
+              zhlint --config "$GITHUB_WORKSPACE"/.github/workflows/.zhlintrc "$file" --output="$output_file" > "$output_file.log" 2>&1
             fi
             set -e
           done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
           linted_failed=0
           for file in ${{ env.ALL_CHANGED_FILES }}; do
             set +e
-            zhlint --config "$GITHUB_WORKSPACE"/ci/.zhlintrc "$file"
+            zhlint --config "$GITHUB_WORKSPACE"/.github/workflows/.zhlintrc "$file"
             if [ $? -ne 0 ]; then
               linted_failed=1
               echo "$file" >> "$file_list"


### PR DESCRIPTION
Added three workflows regarding [#24](https://github.com/hust-open-atom-club/intro2oss/issues/24)

-  `build` : Check website build, triggered by `PRs` and `push` .
-  `lint` : Triggered by `PRs` and `push` with **changed** md files, lint the changed md files with `zhlint`, generating an artifact with `zhlint` log and autofix files .
-  `lint-all`: Same function as `lint`, but triggered manually, checking **all** the md files in the repo .

