### PR TITLE
fix: fix typos for 2-qemu-send-email.md

### DIFF
--- a/docs/ch3/sec4/2-qemu-send-email.md
+++ b/docs/ch3/sec4/2-qemu-send-email.md
@@ -108,7 +108,7 @@ git format-patch HEAD~<number>     \
 
 发送邮件到邮件列表的命令如下：
 
-以 qemu 为例，可以通过 `./script/get_maintainer.pl <patch-file>` 来获取发送对象和抄送对象，
+以 qemu 为例，可以通过 `./scripts/get_maintainer.pl <patch-file>` 来获取发送对象和抄送对象，
 具体发送邮件补丁的命令如下：
 
 ```bash


### PR DESCRIPTION
## 关联章节/文件
- 文档路径：`docs/ch3/sec4/2-qemu-send-email.md`

## 修改类型
- [ ] 内容补充
- [x] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述
- 提交 QEMU patch 时获取发送对象和抄送对象的命令错误

## 本地验证
- [x] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [x] 已执行 `mkdocs serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观